### PR TITLE
fix(proxy): hijack before WriteHeader so CONNECT 200 has no chunked framing

### DIFF
--- a/pkg/service/proxy.go
+++ b/pkg/service/proxy.go
@@ -57,7 +57,12 @@ func (h *CNProxyHandler) httpsProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	w.WriteHeader(http.StatusOK)
+	// Hijack BEFORE writing any response. If we let net/http synthesize the
+	// 200 it adds Transfer-Encoding: chunked (no Content-Length was set), and
+	// RFC 7230 §3.3 / RFC 9112 §6.1 forbid Transfer-Encoding and
+	// Content-Length on a 2xx response to CONNECT. Conforming clients (Go's
+	// net/http transport in particular) then read the tunnel stream through a
+	// chunked decoder, corrupting the TLS handshake.
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
 		http.Error(w, "hijack not supported", http.StatusInternalServerError)
@@ -65,10 +70,11 @@ func (h *CNProxyHandler) httpsProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientConn, _, err := hijacker.Hijack()
+	clientConn, brw, err := hijacker.Hijack()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		h.Logger.Error("failed to hijack", "error", err)
+		return
 	}
 	defer func() {
 		if err := clientConn.Close(); err != nil {
@@ -76,14 +82,25 @@ func (h *CNProxyHandler) httpsProxy(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
+	if _, err := brw.WriteString("HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		h.Logger.Warn("failed to write 200 response", "error", err)
+		return
+	}
+	if err := brw.Flush(); err != nil {
+		h.Logger.Warn("failed to flush 200 response", "error", err)
+		return
+	}
+
+	// Read from brw.Reader, not clientConn, so any bytes the client pipelined
+	// after the CONNECT request (e.g. the start of a TLS ClientHello) that
+	// landed in net/http's buffered reader are forwarded instead of dropped.
 	go func() {
-		if _, e := io.Copy(destConn, clientConn); e != nil {
+		if _, e := io.Copy(destConn, brw.Reader); e != nil {
 			h.Logger.Warn("failed to copy client to destination", "error", e)
 		}
 	}()
 
-	_, err = io.Copy(clientConn, destConn)
-	if err != nil {
+	if _, err := io.Copy(clientConn, destConn); err != nil {
 		h.Logger.Warn("failed to copy destination to client", "error", err)
 	}
 }

--- a/pkg/service/proxy_test.go
+++ b/pkg/service/proxy_test.go
@@ -24,7 +24,7 @@ func TestHttpsProxyConnectResponseHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen backend: %v", err)
 	}
-	defer backend.Close()
+	defer func() { _ = backend.Close() }()
 
 	go func() {
 		for {
@@ -33,7 +33,7 @@ func TestHttpsProxyConnectResponseHeaders(t *testing.T) {
 				return
 			}
 			go func(c net.Conn) {
-				defer c.Close()
+				defer func() { _ = c.Close() }()
 				_, _ = io.Copy(c, c) // echo
 			}(c)
 		}
@@ -60,7 +60,7 @@ func TestHttpsProxyConnectResponseHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}
-	defer proxyConn.Close()
+	defer func() { _ = proxyConn.Close() }()
 
 	target := backend.Addr().String()
 	if _, err := fmt.Fprintf(proxyConn,
@@ -76,7 +76,7 @@ func TestHttpsProxyConnectResponseHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read CONNECT response: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: want 200, got %d", resp.StatusCode)
@@ -114,7 +114,7 @@ func TestHttpsProxyForwardsPipelinedClientBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen backend: %v", err)
 	}
-	defer backend.Close()
+	defer func() { _ = backend.Close() }()
 
 	received := make(chan []byte, 1)
 	go func() {
@@ -122,7 +122,7 @@ func TestHttpsProxyForwardsPipelinedClientBytes(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer c.Close()
+		defer func() { _ = c.Close() }()
 		buf := make([]byte, 64)
 		n, err := c.Read(buf)
 		if err != nil {
@@ -145,7 +145,7 @@ func TestHttpsProxyForwardsPipelinedClientBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial proxy: %v", err)
 	}
-	defer proxyConn.Close()
+	defer func() { _ = proxyConn.Close() }()
 
 	target := backend.Addr().String()
 	const pipelined = "PIPELINED-BYTES"
@@ -165,7 +165,7 @@ func TestHttpsProxyForwardsPipelinedClientBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read CONNECT response: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: want 200, got %d", resp.StatusCode)
 	}

--- a/pkg/service/proxy_test.go
+++ b/pkg/service/proxy_test.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHttpsProxyConnectResponseHeaders pins the fix for the Transfer-Encoding
+// regression: a 2xx response to CONNECT must not advertise Transfer-Encoding or
+// Content-Length (RFC 7230 §3.3 / RFC 9112 §6.1). If net/http auto-frames the
+// response as chunked, Go HTTP clients decode the tunnel as chunked data and
+// the TLS handshake silently breaks.
+func TestHttpsProxyConnectResponseHeaders(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	defer backend.Close()
+
+	go func() {
+		for {
+			c, err := backend.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c) // echo
+			}(c)
+		}
+	}()
+
+	host, _, err := net.SplitHostPort(backend.Addr().String())
+	if err != nil {
+		t.Fatalf("split host: %v", err)
+	}
+
+	handler := &CNProxyHandler{
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AllowedFQDNs: []string{host},
+	}
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy url: %v", err)
+	}
+
+	proxyConn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer proxyConn.Close()
+
+	target := backend.Addr().String()
+	if _, err := fmt.Fprintf(proxyConn,
+		"CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", target, target); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+
+	if err := proxyConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	br := bufio.NewReader(proxyConn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+	if len(resp.TransferEncoding) != 0 {
+		t.Errorf("Transfer-Encoding: want none (RFC 7230 §3.3), got %v", resp.TransferEncoding)
+	}
+	if got := resp.Header.Get("Transfer-Encoding"); got != "" {
+		t.Errorf("Transfer-Encoding header: want empty, got %q", got)
+	}
+	if got := resp.Header.Get("Content-Length"); got != "" {
+		t.Errorf("Content-Length header: want empty (RFC 7230 §3.3), got %q", got)
+	}
+
+	// Verify the tunnel itself works once the response is past.
+	const payload = "ping-through-tunnel\n"
+	if _, err := proxyConn.Write([]byte(payload)); err != nil {
+		t.Fatalf("write to tunnel: %v", err)
+	}
+	got, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if got != payload {
+		t.Errorf("echo: want %q, got %q", payload, got)
+	}
+}
+
+// TestHttpsProxyForwardsPipelinedClientBytes guards against dropping bytes the
+// client may have pipelined immediately after the CONNECT request line. Such
+// bytes land in net/http's bufio.Reader and would be lost if the proxy copied
+// from the raw net.Conn instead of the hijacked bufio.Reader.
+func TestHttpsProxyForwardsPipelinedClientBytes(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
+	}
+	defer backend.Close()
+
+	received := make(chan []byte, 1)
+	go func() {
+		c, err := backend.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 64)
+		n, err := c.Read(buf)
+		if err != nil {
+			received <- nil
+			return
+		}
+		received <- buf[:n]
+	}()
+
+	host, _, _ := net.SplitHostPort(backend.Addr().String())
+	handler := &CNProxyHandler{
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		AllowedFQDNs: []string{host},
+	}
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	proxyURL, _ := url.Parse(proxy.URL)
+	proxyConn, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer proxyConn.Close()
+
+	target := backend.Addr().String()
+	const pipelined = "PIPELINED-BYTES"
+	// Send CONNECT and the pipelined bytes back-to-back so net/http reads them
+	// into its bufio.Reader along with the request.
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n%s",
+		target, target, pipelined)
+	if _, err := proxyConn.Write([]byte(req)); err != nil {
+		t.Fatalf("write CONNECT+payload: %v", err)
+	}
+
+	if err := proxyConn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	br := bufio.NewReader(proxyConn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	select {
+	case got := <-received:
+		if !strings.HasPrefix(string(got), pipelined) {
+			t.Errorf("backend received %q, want prefix %q", got, pipelined)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("backend did not receive pipelined bytes")
+	}
+}


### PR DESCRIPTION
## Summary

- `httpsProxy` calls `w.WriteHeader(http.StatusOK)` before hijacking, so net/http auto-frames the 200 response as `Transfer-Encoding: chunked` (no `Content-Length` was set).
- RFC 7230 §3.3 / RFC 9112 §6.1 forbid `Transfer-Encoding` and `Content-Length` on a 2xx response to CONNECT, and Go's `net/http` transport honors them — it then routes the tunnel stream through a chunked decoder, corrupting the TLS handshake. The client surfaces this as `remote error: tls: protocol version not supported` (alert 70 from the upstream server, because the dechunked bytes hit the wire mangled).
- Fix by hijacking first, writing the `200 Connection Established` line manually, and copying client → destination from the hijacked `bufio.Reader` so any bytes the client pipelined after the CONNECT request are forwarded rather than dropped. Also adds a missing `return` after a hijack failure (previously fell through into the copy goroutines with a nil `clientConn`).

## Repro

The raw response cnproxy sends today for a CONNECT:

```
HTTP/1.1 200 OK
Date: ...
Transfer-Encoding: chunked
```

curl and ad-hoc Go programs happen to tolerate it; a Go binary built with ``go 1.25+`` running a real HTTPS request through the proxy does not — TLS to e.g. `slack.com:443` fails immediately after the tunnel comes up.

## Test plan

- [x] `go test ./pkg/service/... -run TestHttpsProxy` — added two regression tests:
  - `TestHttpsProxyConnectResponseHeaders` asserts no `Transfer-Encoding` / `Content-Length` on the CONNECT 200, then exercises the tunnel with an echo backend.
  - `TestHttpsProxyForwardsPipelinedClientBytes` asserts bytes pipelined immediately after the request line reach the destination.
- [x] Both tests fail against `main` (`Transfer-Encoding: want none, got [chunked]` / `backend did not receive pipelined bytes`) and pass with the fix.
- [x] `go build -buildvcs=false ./...` / `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)