### PR TITLE
ci: build linux/arm64 image alongside amd64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,5 +44,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Add `platforms: linux/amd64,linux/arm64` to the `docker/build-push-action` step so the published `ghcr.io` image becomes a multi-arch manifest.
- No Dockerfile change needed: it already uses `--platform=$BUILDPLATFORM` for the build stage and `CGO_ENABLED=0 GOARCH=$TARGETARCH` for cross-compilation, and the workflow already sets up QEMU and Buildx.

## Test plan
- [ ] Confirm the `Build and Push container image` workflow succeeds on this branch (PR event).
- [ ] After merge to `main`, verify the resulting `ghcr.io/guni1192/cnproxy` image has both `linux/amd64` and `linux/arm64` entries: `docker buildx imagetools inspect ghcr.io/guni1192/cnproxy:main`.